### PR TITLE
Optimize JsonCompleter.parse append-only byte hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to `json_completer` are documented here.
 
 ### Changed
 
-- Reduced `JsonCompleter.parse` allocations and improved throughput for long streamed string values by scanning plain string runs in slices instead of per character.
+- `JsonCompleter#parse` now follows the same append-only incremental contract as `#complete`: growing inputs stay on the hot path, and callers should create a new instance if earlier bytes change.
+- Reduced `JsonCompleter.parse` allocations and improved throughput on append-only streaming inputs by walking the hot path as bytes and keeping string-copy work slice-based.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ result3 = completer.parse('{"users": [{"name": "Alice"}, {"name": "Bob"}]}')
 # => {"users" => [{"name" => "Alice"}, {"name" => "Bob"}]}
 ```
 
+Stateful `JsonCompleter` instances assume append-only input. If earlier bytes change, create a new instance; truncation to a shorter prefix still resets state automatically.
+
 ### String Output with `.complete`
 
 Use `.complete` when you specifically need completed JSON text instead of parsed Ruby objects:
@@ -83,7 +85,7 @@ This is the second-tier option when another layer expects JSON text and you want
 - **Zero reprocessing**: Maintains parsing state to avoid reparsing previously processed data
 - **Linear complexity**: Each chunk processed in O(n) time where n = new data size, not total size
 - **Memory efficient**: Uses token-based accumulation with minimal state overhead
-- **Chunked string scanning**: Copies contiguous non-escape string content in slices instead of per character to reduce allocations on long streamed strings
+- **Byte-oriented string scanning**: Walks JSON input as bytes and copies contiguous non-escape string content in slices to reduce per-character overhead on long streamed strings
 - **Context preservation**: Tracks nested structures without full document analysis
 
 ### Common Use Cases

--- a/lib/json_completer/completion_engine.rb
+++ b/lib/json_completer/completion_engine.rb
@@ -4,29 +4,31 @@ class JsonCompleter
   module CompletionEngine
     def complete(partial_json)
       input = partial_json
+      # Same byte-oriented trick as parse: compare ASCII JSON syntax as integers and avoid
+      # allocating transient 1-character strings in the streaming loop.
+      input_length = input.bytesize
 
-      if @state.nil? || @state.input_length > input.length
+      if @state.nil? || @state.input_length > input_length
         @state = ParsingState.new
       end
 
       return input if input.empty?
       return input if valid_json_primitive_or_document?(input)
 
-      if @state.input_length == input.length && !@state.output_tokens.empty?
+      if @state.input_length == input_length && !@state.output_tokens.empty?
         return finalize_completion(@state.output_tokens.dup, @state.context_stack.dup, @state.incomplete_string_token)
       end
 
       output_tokens = @state.output_tokens.dup
       context_stack = @state.context_stack.dup
       index = @state.last_index
-      length = input.length
       incomplete_string_token = @state.incomplete_string_token
 
       if incomplete_string_token && output_tokens.last&.start_with?('"') && output_tokens.last.end_with?('"')
         output_tokens.pop
       end
 
-      while index < length
+      while index < input_length
         if incomplete_string_token && index == @state.last_index
           index, status = Scanners.scan_string(input, index, incomplete_string_token)
 
@@ -38,32 +40,16 @@ class JsonCompleter
           next
         end
 
-        char = input[index]
+        byte = input.getbyte(index)
         last_significant_char_in_output = get_last_significant_char(output_tokens)
 
-        case char
-        when '{'
-          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
-          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
-          output_tokens << char
-          context_stack << '{'
+        # ASCII byte values: 9/10/13/32 = whitespace, 34 = ", 44 = ,, 45 = -, 58 = :,
+        # 91/93 = [] , 102/110/116 = f/n/t, 123/125 = {}.
+        case byte
+        when 9, 10, 13, 32
+          output_tokens << input.byteslice(index, 1)
           index += 1
-        when '['
-          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
-          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
-          output_tokens << char
-          context_stack << '['
-          index += 1
-        when '}'
-          remove_trailing_comma(output_tokens)
-          output_tokens << char
-          context_stack.pop if !context_stack.empty? && context_stack.last == '{'
-          index += 1
-        when ']'
-          output_tokens << char
-          context_stack.pop if !context_stack.empty? && context_stack.last == '['
-          index += 1
-        when '"'
+        when 34
           ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
           ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
 
@@ -75,30 +61,62 @@ class JsonCompleter
           else
             incomplete_string_token = string_token
           end
-        when ':'
-          remove_trailing_comma(output_tokens) if last_significant_char_in_output == ','
-          output_tokens << char
-          index += 1
-        when ','
+        when 44
           remove_trailing_comma(output_tokens)
-          output_tokens << char
+          output_tokens << ','
           index += 1
-        when 't', 'f', 'n'
-          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
-          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
-
-          keyword_val, consumed = Scanners.scan_keyword_literal(input, index, KEYWORD_MAP[char.downcase])
-          output_tokens << keyword_val
-          index += consumed
-        when '-', '0'..'9'
+        when 45, 48..57
           ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
           ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
 
           num_str, consumed = Scanners.scan_number_literal(input, index)
           output_tokens << num_str
           index += consumed
-        when /\s/
-          output_tokens << char
+        when 58
+          remove_trailing_comma(output_tokens) if last_significant_char_in_output == ','
+          output_tokens << ':'
+          index += 1
+        when 91
+          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
+          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
+          output_tokens << '['
+          context_stack << '['
+          index += 1
+        when 93
+          output_tokens << ']'
+          context_stack.pop if !context_stack.empty? && context_stack.last == '['
+          index += 1
+        when 102
+          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
+          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
+
+          keyword_val, consumed = Scanners.scan_keyword_literal(input, index, KEYWORD_MAP['f'])
+          output_tokens << keyword_val
+          index += consumed
+        when 110
+          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
+          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
+
+          keyword_val, consumed = Scanners.scan_keyword_literal(input, index, KEYWORD_MAP['n'])
+          output_tokens << keyword_val
+          index += consumed
+        when 116
+          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
+          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
+
+          keyword_val, consumed = Scanners.scan_keyword_literal(input, index, KEYWORD_MAP['t'])
+          output_tokens << keyword_val
+          index += consumed
+        when 123
+          ensure_comma_before_new_item(output_tokens, context_stack, last_significant_char_in_output)
+          ensure_colon_if_value_expected(output_tokens, context_stack, last_significant_char_in_output)
+          output_tokens << '{'
+          context_stack << '{'
+          index += 1
+        when 125
+          remove_trailing_comma(output_tokens)
+          output_tokens << '}'
+          context_stack.pop if !context_stack.empty? && context_stack.last == '{'
           index += 1
         else
           index += 1
@@ -109,7 +127,7 @@ class JsonCompleter
         output_tokens: output_tokens,
         context_stack: context_stack,
         last_index: index,
-        input_length: length,
+        input_length: input_length,
         incomplete_string_token: incomplete_string_token
       )
 

--- a/lib/json_completer/parser_engine.rb
+++ b/lib/json_completer/parser_engine.rb
@@ -4,72 +4,79 @@ class JsonCompleter
   module ParserEngine
     def parse(partial_json)
       input = partial_json
+      # The hot path works on raw bytes, not 1-character Ruby strings. JSON punctuation is ASCII,
+      # so getbyte/bytesize let us compare cheap integers while multibyte UTF-8 payload stays intact.
+      input_length = input.bytesize
 
       if @parse_state.nil? ||
-         @parse_state.input_length > input.length ||
-         (@parse_state.input_snapshot && !input.start_with?(@parse_state.input_snapshot))
+         @parse_state.input_length > input_length ||
+         (@parse_state.input_length < input_length && reset_parse_state_for_input_growth?(input))
+        @parse_state = self.class.new_parse_state
+      elsif @parse_state.input_length == input_length
+        if @parse_state.input_snapshot == input
+          finalize_parse_result
+          return @parse_state.root
+        end
+
         @parse_state = self.class.new_parse_state
       end
 
       return nil if input.empty?
 
       begin
-        if @parse_state.input_length == input.length
-          finalize_parse_result
-          return @parse_state.root
-        end
-
         prepare_parse_state_for_incremental_input
 
         index = @parse_state.last_index
-        while index < input.length
+        while index < input_length
           if @parse_state.token_state
             index = continue_parse_token(input, index)
             next
           end
 
-          char = input[index]
-          if top_level_value_complete? && char !~ /\s/
+          byte = input.getbyte(index)
+          if top_level_value_complete? && !whitespace_byte?(byte)
             raise ParseError, 'unexpected token after top-level value'
           end
 
-          case char
-          when /\s/
+          # ASCII byte values: 9/10/13/32 = whitespace, 34 = ", 44 = ,, 45 = -, 58 = :,
+          # 91/93 = [] , 102/110/116 = f/n/t, 123/125 = {}.
+          case byte
+          when 9, 10, 13, 32
             index += 1
-          when '{'
-            start_parse_container({})
-            index += 1
-          when '['
-            start_parse_container([])
-            index += 1
-          when '}'
-            close_parse_object!
-            index += 1
-          when ']'
-            close_parse_array!
-            index += 1
-          when '"'
+          when 34
             start_parse_string_token
             index += 1
-          when ':'
-            parse_colon!
-            index += 1
-          when ','
+          when 44
             parse_comma!
             index += 1
-          when 't', 'f', 'n'
-            start_parse_keyword_token(char)
+          when 45, 48..57
+            start_parse_number_token(byte)
             index += 1
-          when '-', '0'..'9'
-            start_parse_number_token(char)
+          when 58
+            parse_colon!
+            index += 1
+          when 91
+            start_parse_container([])
+            index += 1
+          when 93
+            close_parse_array!
+            index += 1
+          when 102, 110, 116
+            start_parse_keyword_token(byte)
+            index += 1
+          when 123
+            start_parse_container({})
+            index += 1
+          when 125
+            close_parse_object!
             index += 1
           else
-            raise ParseError, "unexpected token #{char.inspect}"
+            raise ParseError, "unexpected token #{input.byteslice(index, 1).inspect}"
           end
         end
 
         @parse_state.last_index = index
-        @parse_state.input_length = input.length
+        @parse_state.input_length = input_length
         @parse_state.input_snapshot = input
         finalize_parse_result
         @parse_state.root
@@ -172,10 +179,10 @@ class JsonCompleter
       @parse_state.token_state = nil
     end
 
-    def start_parse_number_token(first_char)
+    def start_parse_number_token(first_byte)
       slot = parse_value_slot!
       token = Scanners::NumberToken.new(slot: slot)
-      token.append(first_char)
+      token.append_byte(first_byte)
       assign_parse_slot(slot, token.parsed_value)
       transition_after_parse_value(slot)
       @parse_state.token_state = token
@@ -183,21 +190,22 @@ class JsonCompleter
 
     def continue_parse_number_token(input, index)
       token = @parse_state.token_state
+      length = input.bytesize
 
-      while index < input.length && token.append(input[index])
+      while index < length && token.append_byte(input.getbyte(index))
         assign_parse_slot(token.slot, token.parsed_value)
         index += 1
       end
 
       raise ParseError, 'invalid number literal' if token.invalid?
 
-      @parse_state.token_state = nil if index < input.length
+      @parse_state.token_state = nil if index < length
       index
     end
 
-    def start_parse_keyword_token(first_char)
+    def start_parse_keyword_token(first_byte)
       slot = parse_value_slot!
-      token = Scanners::KeywordToken.new(slot: slot, target: KEYWORD_MAP[first_char], matched: 1)
+      token = Scanners::KeywordToken.new(slot: slot, target: keyword_target_for_byte(first_byte), matched: 1)
       assign_parse_slot(slot, token.parsed_value)
       transition_after_parse_value(slot)
       @parse_state.token_state = token
@@ -205,14 +213,15 @@ class JsonCompleter
 
     def continue_parse_keyword_token(input, index)
       token = @parse_state.token_state
+      length = input.bytesize
 
-      while index < input.length && token.matched < token.target.length && token.append(input[index])
+      while index < length && token.matched < token.target.length && token.append_byte(input.getbyte(index))
         index += 1
       end
 
-      raise ParseError, 'invalid keyword literal' if token.matched < token.target.length && index < input.length
+      raise ParseError, 'invalid keyword literal' if token.matched < token.target.length && index < length
 
-      @parse_state.token_state = nil if index < input.length || token.matched == token.target.length
+      @parse_state.token_state = nil if index < length || token.matched == token.target.length
       index
     end
 
@@ -238,7 +247,6 @@ class JsonCompleter
 
         context.mode = :key_or_end
         context.current_key = nil
-
       end
     end
 
@@ -338,6 +346,39 @@ class JsonCompleter
       token.visible_key_replaced_present = token.context.container.key?(current_key)
       token.visible_key_replaced_value = token.context.container[current_key]
       token.context.container[current_key] = nil
+    end
+
+    def reset_parse_state_for_input_growth?(input)
+      return false unless @parse_state.input_snapshot
+      return false unless prefix_validation_required?
+
+      !input.start_with?(@parse_state.input_snapshot)
+    end
+
+    def prefix_validation_required?
+      @parse_state.context_stack.empty?
+    end
+
+    def keyword_target_for_byte(byte)
+      case byte
+      when 102
+        'false'
+      when 110
+        'null'
+      when 116
+        'true'
+      else
+        raise ParseError, "unexpected keyword token byte: #{byte}"
+      end
+    end
+
+    def whitespace_byte?(byte)
+      case byte
+      when 9, 10, 13, 32
+        true
+      else
+        false
+      end
     end
   end
 

--- a/lib/json_completer/scanners.rb
+++ b/lib/json_completer/scanners.rb
@@ -2,9 +2,6 @@
 
 class JsonCompleter
   module Scanners
-    COMPLETION_STRING_SPECIAL_PATTERN = /["\\]/
-    PARSED_STRING_SPECIAL_PATTERN = /["\\\x00-\x1F]/
-
     class CompletionStringToken < Struct.new(:buffer, :escape_state, :unicode_digits, keyword_init: true)
       def initialize(buffer: nil, escape_state: nil, unicode_digits: nil)
         buffer ||= StringIO.new
@@ -17,19 +14,16 @@ class JsonCompleter
         self.escape_state = :backslash
       end
 
-      def append_char(char)
-        buffer << char
-      end
-
       def append_slice(input, start_index, length)
-        buffer << input.slice(start_index, length)
+        buffer << input.byteslice(start_index, length)
       end
 
-      def append_simple_escape(char)
-        buffer << char
+      # completion keeps escape bytes verbatim, so convert the ASCII byte back into a 1-byte string.
+      def append_simple_escape(byte)
+        buffer << byte.chr(Encoding::UTF_8)
       end
 
-      def valid_simple_escape?(_char)
+      def valid_simple_escape?(_byte)
         true
       end
 
@@ -38,9 +32,9 @@ class JsonCompleter
         buffer << 'u'
       end
 
-      def append_unicode_digit(char)
-        unicode_digits << char
-        buffer << char
+      def append_unicode_digit(byte)
+        unicode_digits << byte
+        buffer << byte.chr(Encoding::UTF_8)
       end
 
       def finish_unicode_escape!; end
@@ -91,34 +85,31 @@ class JsonCompleter
         self.escape_state = :backslash
       end
 
-      def append_char(char)
-        buffer << char
-      end
-
       def append_slice(input, start_index, length)
-        buffer << input.slice(start_index, length)
+        buffer << input.byteslice(start_index, length)
       end
 
-      def append_simple_escape(char)
-        buffer << case char
-                  when 'b'
+      # ASCII escape bytes: 98/102/110/114/116 = b/f/n/r/t.
+      def append_simple_escape(byte)
+        buffer << case byte
+                  when 98
                     "\b"
-                  when 'f'
+                  when 102
                     "\f"
-                  when 'n'
+                  when 110
                     "\n"
-                  when 'r'
+                  when 114
                     "\r"
-                  when 't'
+                  when 116
                     "\t"
                   else
-                    char
+                    byte
                   end
       end
 
-      def valid_simple_escape?(char)
-        case char
-        when '"', '\\', '/', 'b', 'f', 'n', 'r', 't'
+      def valid_simple_escape?(byte)
+        case byte
+        when 34, 92, 47, 98, 102, 110, 114, 116
           true
         else
           false
@@ -129,8 +120,8 @@ class JsonCompleter
         self.unicode_digits = String.new
       end
 
-      def append_unicode_digit(char)
-        unicode_digits << char
+      def append_unicode_digit(byte)
+        unicode_digits << byte
       end
 
       def finish_unicode_escape!
@@ -176,94 +167,97 @@ class JsonCompleter
         self.raw ||= String.new
       end
 
-      def append(char)
+      # append_byte consumes ASCII bytes, not 1-character strings:
+      # 45 = -, 46 = ., 48..57 = 0..9, 69/101 = E/e.
+      def append_byte(byte)
         case phase
         when nil
-          case char
-          when '-'
-            raw << char
+          case byte
+          when 45
+            raw << byte
             self.phase = :sign
-          when '0'
-            raw << char
+          when 48
+            raw << byte
             self.phase = :zero
-          when /[0-9]/
-            raw << char
+          when 49..57
+            raw << byte
             self.phase = :int
           else
             return false
           end
         when :sign
-          case char
-          when '0'
-            raw << char
+          case byte
+          when 48
+            raw << byte
             self.phase = :zero
-          when /[0-9]/
-            raw << char
+          when 49..57
+            raw << byte
             self.phase = :int
-          when '.'
-            raw << char
+          when 46
+            raw << byte
             self.phase = :frac_start
           else
             return false
           end
         when :zero
-          if char.match?(/[0-9]/)
+          if Scanners.digit_byte?(byte)
             self.invalid = true
             return false
-          elsif char == '.'
-            raw << char
+          elsif byte == 46
+            raw << byte
             self.phase = :frac_start
-          elsif %w[e E].include?(char)
-            raw << char
+          elsif Scanners.exponent_byte?(byte)
+            raw << byte
             self.phase = :exp_start
           else
             return false
           end
         when :int
-          if char.match?(/[0-9]/)
-            raw << char
-          elsif char == '.'
-            raw << char
+          if Scanners.digit_byte?(byte)
+            raw << byte
+          elsif byte == 46
+            raw << byte
             self.phase = :frac_start
-          elsif %w[e E].include?(char)
-            raw << char
+          elsif Scanners.exponent_byte?(byte)
+            raw << byte
             self.phase = :exp_start
           else
             return false
           end
         when :frac_start
-          return false unless char.match?(/[0-9]/)
+          return false unless Scanners.digit_byte?(byte)
 
-          raw << char
+          raw << byte
           self.phase = :frac
         when :frac
-          if char.match?(/[0-9]/)
-            raw << char
-          elsif %w[e E].include?(char)
-            raw << char
+          if Scanners.digit_byte?(byte)
+            raw << byte
+          elsif Scanners.exponent_byte?(byte)
+            raw << byte
             self.phase = :exp_start
           else
             return false
           end
         when :exp_start
-          if ['+', '-'].include?(char)
-            raw << char
+          case byte
+          when 43, 45
+            raw << byte
             self.phase = :exp_sign
-          elsif char.match?(/[0-9]/)
-            raw << char
+          when 48..57
+            raw << byte
             self.phase = :exp
           else
             return false
           end
         when :exp_sign
-          return false unless char.match?(/[0-9]/)
+          return false unless Scanners.digit_byte?(byte)
 
-          raw << char
+          raw << byte
           self.phase = :exp
         when :exp
-          return false unless char.match?(/[0-9]/)
+          return false unless Scanners.digit_byte?(byte)
 
-          raw << char
+          raw << byte
         end
 
         true
@@ -301,9 +295,9 @@ class JsonCompleter
         super
       end
 
-      def append(char)
+      def append_byte(byte)
         return false if matched >= target.length
-        return false unless char.downcase == target[matched]
+        return false unless (byte | 0x20) == target.getbyte(matched)
 
         self.matched += 1
         true
@@ -323,15 +317,17 @@ class JsonCompleter
 
     def scan_string(input, index, token)
       strict = token.is_a?(ParsedStringToken)
-      length = input.length
-      special_pattern = strict ? PARSED_STRING_SPECIAL_PATTERN : COMPLETION_STRING_SPECIAL_PATTERN
+      # JSON string syntax is ASCII, so scanning bytes is safe here: multibyte UTF-8 content is
+      # treated as opaque payload and copied via byteslice until we hit an ASCII delimiter/escape.
+      length = input.bytesize
+      segment_start = index
 
       while index < length
-        char = input[index]
+        byte = input.getbyte(index)
 
         if token.unicode_digits
-          if char.match?(/[0-9a-fA-F]/)
-            token.append_unicode_digit(char)
+          if hex_digit_byte?(byte)
+            token.append_unicode_digit(byte)
             index += 1
 
             if token.unicode_digits.length == 4
@@ -341,6 +337,7 @@ class JsonCompleter
               return [index, :invalid_unicode] if status == :invalid_unicode
             end
 
+            segment_start = index
             next
           end
 
@@ -350,64 +347,67 @@ class JsonCompleter
         end
 
         if token.escape_state == :backslash
-          if strict && token.pending_high_surrogate && char != 'u'
+          if strict && token.pending_high_surrogate && byte != 117
             return [index, :invalid_unicode]
           end
 
-          if char == 'u'
+          if byte == 117
             token.start_unicode_escape!
             index += 1
+            segment_start = index
             next
           end
 
-          return [index, :invalid_escape] unless token.valid_simple_escape?(char)
+          return [index, :invalid_escape] unless token.valid_simple_escape?(byte)
 
-          token.append_simple_escape(char)
+          token.append_simple_escape(byte)
           token.escape_state = nil
           index += 1
+          segment_start = index
           next
         end
 
-        if strict && token.pending_high_surrogate && char != '\\'
+        if strict && token.pending_high_surrogate && byte != 92
           return [index, :invalid_unicode]
         end
 
-        special_index = input.index(special_pattern, index)
-        if special_index.nil?
-          token.append_slice(input, index, length - index)
-          return [length, :incomplete]
-        end
+        if byte == 34
+          token.append_slice(input, segment_start, index - segment_start) if index > segment_start
 
-        if special_index > index
-          token.append_slice(input, index, special_index - index)
-          index = special_index
-          char = input[index]
-        end
-
-        case char
-        when '\\'
-          token.start_escape!
-          index += 1
-        when '"'
           if strict && token.pending_high_surrogate
             return [index, :invalid_unicode]
           end
 
           token.terminate!
           return [index + 1, :terminated]
-        else
+        end
+
+        if byte == 92
+          token.append_slice(input, segment_start, index - segment_start) if index > segment_start
+          token.start_escape!
+          index += 1
+          segment_start = index
+          next
+        end
+
+        if strict && byte < 0x20
+          token.append_slice(input, segment_start, index - segment_start) if index > segment_start
           return [index, :invalid_control_character]
         end
+
+        index += 1
       end
 
+      token.append_slice(input, segment_start, index - segment_start) if index > segment_start
       [index, :incomplete]
     end
 
     def scan_number_literal(input, index)
       start_index = index
       token = NumberToken.new
+      length = input.bytesize
 
-      while index < input.length && token.append(input[index])
+      while index < length && token.append_byte(input.getbyte(index))
         index += 1
       end
 
@@ -417,14 +417,32 @@ class JsonCompleter
     def scan_keyword_literal(input, index, target_keyword)
       start_index = index
       token = KeywordToken.new(target: target_keyword)
+      length = input.bytesize
 
-      while index < input.length && token.append(input[index])
+      while index < length && token.append_byte(input.getbyte(index))
         index += 1
       end
 
-      return [input[start_index], 1] if token.matched.zero?
+      return [input.byteslice(start_index, 1), 1] if token.matched.zero?
 
       [target_keyword, index - start_index]
+    end
+
+    def digit_byte?(byte)
+      byte.between?(48, 57)
+    end
+
+    def exponent_byte?(byte)
+      case byte
+      when 69, 101
+        true
+      else
+        false
+      end
+    end
+
+    def hex_digit_byte?(byte)
+      digit_byte?(byte) || byte.between?(65, 70) || byte.between?(97, 102)
     end
   end
 end

--- a/spec/json_completer_parse_spec.rb
+++ b/spec/json_completer_parse_spec.rb
@@ -257,6 +257,16 @@ RSpec.describe JsonCompleter do
       expect_incremental_parse_result(completer, '{"name":', { 'name' => nil })
     end
 
+    it 'reuses the same root object when growth only adds trailing whitespace' do
+      completer = JsonCompleter.new
+
+      result1 = completer.parse('{"a":1}')
+      result2 = completer.parse('{"a":1} ')
+
+      expect(result2).to equal(result1)
+      expect(result2).to eq({ 'a' => 1 })
+    end
+
     it 'handles empty input' do
       completer = JsonCompleter.new
 
@@ -292,6 +302,14 @@ RSpec.describe JsonCompleter do
 
       expect_incremental_parse_result(completer, '[{"id":', [{ 'id' => nil }])
       expect_incremental_parse_result(completer, '[{"id":1,"name":', [{ 'id' => 1, 'name' => nil }])
+    end
+
+    it 'handles incremental multibyte strings' do
+      completer = JsonCompleter.new
+
+      expect_incremental_parse_result(completer, '{"emoji":"😀', { 'emoji' => '😀' })
+      expect_incremental_parse_result(completer, '{"emoji":"😀 привет', { 'emoji' => '😀 привет' })
+      expect_incremental_parse_result(completer, '{"emoji":"😀 привет"}', { 'emoji' => '😀 привет' })
     end
 
     it 'handles nil completer parameter' do


### PR DESCRIPTION
## Summary

Optimize `JsonCompleter.parse` for append-only streaming input.

The old hot path still paid for `input.start_with?(input_snapshot)` on every growing chunk to prove the new input shared the old prefix. On long streams that turns into a repeated `memcmp` over already-processed data and showed up as the dominant profiler frame. This change keeps the existing parsing behavior for append-only streams, switches the syntax dispatch/scanners to raw ASCII bytes, and adds inline comments around the byte-oriented path so the optimization stays reviewable.

## Before / after

Benchmark command:

```bash
JSON_COMPLETER_BENCHMARK=1 bundle exec rspec spec/parse_benchmark_spec.rb
```

Benchmark settings from the spec run:
- payload bytes: `77690`
- prefixes: `9712`
- iterations: `50`
- chunk size: `8`

### `parse`

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| total runtime | `1.2887s` | `0.8435s` | `34.5% faster` |
| per iteration | `25.774ms` | `16.870ms` | `34.5% faster` |
| allocated objects | `2,047,568` | `994,865` | `51.4% fewer` |
| heap growth bytes | `196,608` | `0` | `eliminated` |

### Relative to `complete + JSON.parse`

| Metric | Before | After |
| --- | ---: | ---: |
| speedup | `12.93x` | `19.89x` |
| allocation reduction | `8.83x` | `17.14x` |

## What changed

- removed the repeated full-prefix `start_with?` check from the append-only parse hot path
- kept parse state resets for truncation, same-length edits, and completed top-level values
- switched parser/completion dispatch and shared scanners to byte-oriented loops (`bytesize`/`getbyte`/`byteslice`)
- added an incremental multibyte string parse spec to guard the byte path
- documented the append-only stateful-instance contract in `README.md` and `CHANGELOG.md`
- added inline comments explaining the byte constants and why the optimization is safe for UTF-8 payloads

## Why this helps

Most streaming updates are append-only and mostly boring bytes.

Before:
- compare the whole prior prefix with `start_with?` on every chunk
- branch on 1-character strings in the main dispatch/scanner loops
- keep paying that cost as the stream grows

After:
- trust append-only stateful input and only reset on the cases that actually need it
- branch on ASCII byte values instead of allocating/transcoding tiny strings
- keep multibyte string content intact by copying plain runs with `byteslice`

Same result, less repeated work.

The profiler signal matched that story: `rb_str_start_with` dominated the sample before the change and disappeared from the hot-path sample after it.

## Validation

- `bundle exec rubocop`
- `bundle exec rspec`
- `JSON_COMPLETER_BENCHMARK=1 bundle exec rspec spec/parse_benchmark_spec.rb`
